### PR TITLE
Allow evaluating on all domains after model finishes training

### DIFF
--- a/zero/ner/main.py
+++ b/zero/ner/main.py
@@ -116,7 +116,7 @@ def run(common_args, **task_args):
     torch.cuda.empty_cache()
 
     if args.do_eval:
-        dozen_path, luke_path, rgcn_path = get_saved_paths(args, tag="latest")
+        dozen_path, luke_path, rgcn_path = get_saved_paths(args, tag="last")
 
         luke = LukeForNamedEntityRecognition(args, len(processor.get_labels()))
         luke.load_state_dict(torch.load(luke_path, map_location="cpu"))

--- a/zero/utils/evaluator.py
+++ b/zero/utils/evaluator.py
@@ -7,8 +7,11 @@ from tqdm import tqdm
 from zero.utils.loader import load_and_cache_examples
 
 
-def evaluate(args, model, fold, all_entities, output_file=None, return_report=False):
-    dataloader, examples, features, processor = load_and_cache_examples(args, fold, all_entities)
+def evaluate(args, model, fold, all_entities, output_file=None, return_report=False,
+             test_domain_forced=None):
+    dataloader, examples, features, processor = \
+        load_and_cache_examples(args, fold, all_entities,
+                                test_domain_forced=test_domain_forced)
     domain_label_map = processor.get_domain_labels()
     all_predictions = defaultdict(dict)
 

--- a/zero/utils/evaluator.py
+++ b/zero/utils/evaluator.py
@@ -7,11 +7,9 @@ from tqdm import tqdm
 from zero.utils.loader import load_and_cache_examples
 
 
-def evaluate(args, model, fold, all_entities, output_file=None, return_report=False,
-             test_domain_forced=None):
+def evaluate(args, model, fold, all_entities, output_file=None, return_report=False):
     dataloader, examples, features, processor = \
-        load_and_cache_examples(args, fold, all_entities,
-                                test_domain_forced=test_domain_forced)
+        load_and_cache_examples(args, fold, all_entities)
     domain_label_map = processor.get_domain_labels()
     all_predictions = defaultdict(dict)
 

--- a/zero/utils/loader.py
+++ b/zero/utils/loader.py
@@ -114,9 +114,13 @@ def get_saved_paths(args, tag=None):
     return dozen_path, luke_path, rgcn_path
 
 
-def load_and_cache_examples(args, fold, inter_domain_entities, random_sampling=True):
+def load_and_cache_examples(args, fold, inter_domain_entities, random_sampling=True,
+                            test_domain_forced=None):
     if args.local_rank not in (-1, 0) and fold == "train":
         torch.distributed.barrier()
+
+    if test_domain_forced:
+        args.test_domain = test_domain_forced
 
     processor = NERProcessor(os.path.join(args.data_dir, "ner"),
                              args.train_domains, args.dev_domain, args.test_domain)

--- a/zero/utils/loader.py
+++ b/zero/utils/loader.py
@@ -114,13 +114,9 @@ def get_saved_paths(args, tag=None):
     return dozen_path, luke_path, rgcn_path
 
 
-def load_and_cache_examples(args, fold, inter_domain_entities, random_sampling=True,
-                            test_domain_forced=None):
+def load_and_cache_examples(args, fold, inter_domain_entities, random_sampling=True):
     if args.local_rank not in (-1, 0) and fold == "train":
         torch.distributed.barrier()
-
-    if test_domain_forced:
-        args.test_domain = test_domain_forced
 
     processor = NERProcessor(os.path.join(args.data_dir, "ner"),
                              args.train_domains, args.dev_domain, args.test_domain)


### PR DESCRIPTION
This pull request allows to evaluate performance on all domains after training on a given train domain, dev domain using the CLI argument `--eval-all` (`default=False`).

I can run the code on Colab without any runtime errors but I am not sure if I have any logical errors that will make the obtained results incorrect. Can you take a quick look and see if the logic is sound?